### PR TITLE
Add dashboard summary metrics

### DIFF
--- a/AccountingApp/DashboardWindow.xaml
+++ b/AccountingApp/DashboardWindow.xaml
@@ -14,7 +14,31 @@
         <TabControl>
             <TabItem Header="Home">
                 <Grid Background="White">
-                    <TextBlock Text="Welcome to the Accounting Dashboard" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock Text="Welcome to the Accounting Dashboard" FontSize="24" HorizontalAlignment="Center"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,0">
+                            <StackPanel Margin="10" HorizontalAlignment="Center">
+                                <TextBlock Text="Total Vendors" HorizontalAlignment="Center"/>
+                                <TextBlock x:Name="VendorCountTextBlock" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Margin="10" HorizontalAlignment="Center">
+                                <TextBlock Text="Total Transactions" HorizontalAlignment="Center"/>
+                                <TextBlock x:Name="TransactionCountTextBlock" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Margin="10" HorizontalAlignment="Center">
+                                <TextBlock Text="Total Credit" HorizontalAlignment="Center"/>
+                                <TextBlock x:Name="SummaryCreditTextBlock" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Margin="10" HorizontalAlignment="Center">
+                                <TextBlock Text="Total Debit" HorizontalAlignment="Center"/>
+                                <TextBlock x:Name="SummaryDebitTextBlock" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Margin="10" HorizontalAlignment="Center">
+                                <TextBlock Text="Balance" HorizontalAlignment="Center"/>
+                                <TextBlock x:Name="SummaryBalanceTextBlock" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
                 </Grid>
             </TabItem>
             <TabItem Header="Users">

--- a/AccountingApp/DashboardWindow.xaml.cs
+++ b/AccountingApp/DashboardWindow.xaml.cs
@@ -118,6 +118,7 @@ namespace AccountingApp
                     // Update vendor combo boxes for filtering and adding transactions
                     TransactionVendorFilterComboBox.ItemsSource = Vendors;
                     AddTransactionVendorComboBox.ItemsSource = Vendors;
+                    UpdateDashboardSummary();
                 }
             }
             catch (Exception ex)
@@ -156,6 +157,7 @@ namespace AccountingApp
                     // Display all transactions by default
                     TransactionsDataGrid.ItemsSource = new ObservableCollection<TransactionViewModel>(AllTransactions);
                     CalculateTotals(AllTransactions);
+                    UpdateDashboardSummary();
                 }
             }
             catch (Exception ex)
@@ -253,6 +255,36 @@ namespace AccountingApp
             TotalCreditTextBlock.Text = totalCredit.ToString("0.00");
             TotalDebitTextBlock.Text = totalDebit.ToString("0.00");
             BalanceTextBlock.Text = balance.ToString("0.00");
+        }
+
+        // Update summary values shown on the Home tab
+        private void UpdateDashboardSummary()
+        {
+            if (VendorCountTextBlock != null)
+            {
+                VendorCountTextBlock.Text = Vendors.Count.ToString();
+            }
+            if (TransactionCountTextBlock != null)
+            {
+                TransactionCountTextBlock.Text = AllTransactions.Count.ToString();
+            }
+
+            decimal totalCredit = AllTransactions.Where(t => string.Equals(t.Type, "Credit", StringComparison.OrdinalIgnoreCase)).Sum(t => t.Amount);
+            decimal totalDebit = AllTransactions.Where(t => string.Equals(t.Type, "Debit", StringComparison.OrdinalIgnoreCase)).Sum(t => t.Amount);
+            decimal balance = totalCredit - totalDebit;
+
+            if (SummaryCreditTextBlock != null)
+            {
+                SummaryCreditTextBlock.Text = totalCredit.ToString("0.00");
+            }
+            if (SummaryDebitTextBlock != null)
+            {
+                SummaryDebitTextBlock.Text = totalDebit.ToString("0.00");
+            }
+            if (SummaryBalanceTextBlock != null)
+            {
+                SummaryBalanceTextBlock.Text = balance.ToString("0.00");
+            }
         }
 
         // Vendor model


### PR DESCRIPTION
## Summary
- Add Home tab summary showing totals for vendors, transactions, credits, debits, and balance
- Compute and refresh summary metrics whenever vendors or transactions load

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when updating repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689b98f2984c833083a40c9ca380d762