### PR TITLE
Handle offline login in demo

### DIFF
--- a/AccountingApp/LoginWindow.xaml.cs
+++ b/AccountingApp/LoginWindow.xaml.cs
@@ -62,6 +62,12 @@ namespace AccountingApp
         /// </summary>
         private async Task<bool> AuthenticateAsync(string username, string password)
         {
+            // Allow an offline demo login without contacting the server.
+            if (username == "admin" && password == "password")
+            {
+                return true;
+            }
+
             var apiUrl = "http://localhost:5000/api/auth/login";
 
             try


### PR DESCRIPTION
## Summary
- Allow demo login without contacting the API by recognizing `admin`/`password` credentials

## Testing
- `dotnet build Calculator.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b943a9dd883309520d34f51fa75f2