### PR TITLE
Add update and edit actions to transaction grid

### DIFF
--- a/AccountingApp/DashboardWindow.xaml
+++ b/AccountingApp/DashboardWindow.xaml
@@ -95,10 +95,14 @@
                             <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="80" IsReadOnly="True"/>
                             <DataGridTextColumn Header="Amount" Binding="{Binding Amount}" Width="100" IsReadOnly="True"/>
                             <DataGridTextColumn Header="Description" Binding="{Binding Description, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
-                            <DataGridTemplateColumn Header="Actions" Width="100" IsReadOnly="True">
+                            <DataGridTemplateColumn Header="Actions" Width="200" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <Button Content="Delete" Tag="{Binding Id}" Click="DeleteTransaction_Click"/>
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                            <Button Content="Edit" Margin="0,0,5,0" Click="EditTransaction_Click"/>
+                                            <Button Content="Update" Margin="0,0,5,0" Tag="{Binding Id}" Click="UpdateTransaction_Click"/>
+                                            <Button Content="Delete" Tag="{Binding Id}" Click="DeleteTransaction_Click"/>
+                                        </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>


### PR DESCRIPTION
## Summary
- add Edit, Update, and Delete buttons to transaction grid
- implement handlers to refresh and edit transactions

## Testing
- `dotnet build Calculator.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ce24cbe3083308fdaecccf4565260