### PR TITLE
Improve transaction editing workflow and UI

### DIFF
--- a/AccountingApp/DashboardWindow.xaml
+++ b/AccountingApp/DashboardWindow.xaml
@@ -1,6 +1,7 @@
-﻿<Window x:Class="AccountingApp.DashboardWindow"
+<Window x:Class="AccountingApp.DashboardWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         Title="Dashboard"
         WindowStartupLocation="CenterOwner"
         WindowState="Maximized"
@@ -84,24 +85,60 @@
                 </DockPanel>
             </TabItem>
             <TabItem Header="Transactions">
+                <TabItem.Resources>
+                    <Style x:Key="ActionButtonStyle" TargetType="Button">
+                        <Setter Property="FontFamily" Value="Segoe UI"/>
+                        <Setter Property="FontSize" Value="14"/>
+                        <Setter Property="Padding" Value="6,3"/>
+                        <Setter Property="Margin" Value="2"/>
+                        <Setter Property="MinWidth" Value="70"/>
+                        <Setter Property="Height" Value="30"/>
+                        <Setter Property="Background" Value="#1976D2"/>
+                        <Setter Property="Foreground" Value="White"/>
+                    </Style>
+                    <Style x:Key="RefreshButtonStyle" TargetType="Button" BasedOn="{StaticResource ActionButtonStyle}">
+                        <Setter Property="Background" Value="#009688"/>
+                    </Style>
+                    <Style x:Key="DeleteButtonStyle" TargetType="Button" BasedOn="{StaticResource ActionButtonStyle}">
+                        <Setter Property="Background" Value="#D32F2F"/>
+                    </Style>
+                </TabItem.Resources>
                 <!-- Transaction management: view, add and delete transactions -->
                 <DockPanel>
-                    <Button Content="Refresh" DockPanel.Dock="Top" Margin="10" Click="RefreshTransactions_Click"/>
-                    <DataGrid x:Name="TransactionsDataGrid" AutoGenerateColumns="False" Margin="10" DockPanel.Dock="Top" CanUserAddRows="False" RowEditEnding="TransactionsDataGrid_RowEditEnding">
+                    <Button Content="Refresh" DockPanel.Dock="Top" Margin="10" Click="RefreshTransactions_Click" Style="{StaticResource RefreshButtonStyle}"/>
+                    <DataGrid x:Name="TransactionsDataGrid" AutoGenerateColumns="False" Margin="10" DockPanel.Dock="Top" CanUserAddRows="False">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="50" IsReadOnly="True"/>
                             <DataGridTextColumn Header="Vendor" Binding="{Binding VendorName}" Width="150" IsReadOnly="True"/>
                             <DataGridTextColumn Header="Date" Binding="{Binding Date, StringFormat=d}" Width="120" IsReadOnly="True"/>
-                            <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="80" IsReadOnly="True"/>
-                            <DataGridTextColumn Header="Amount" Binding="{Binding Amount}" Width="100" IsReadOnly="True"/>
+                            <DataGridComboBoxColumn Header="Type" SelectedItemBinding="{Binding Type, UpdateSourceTrigger=PropertyChanged}" Width="80">
+                                <DataGridComboBoxColumn.ItemsSource>
+                                    <x:Array Type="{x:Type sys:String}">
+                                        <sys:String>Credit</sys:String>
+                                        <sys:String>Debit</sys:String>
+                                    </x:Array>
+                                </DataGridComboBoxColumn.ItemsSource>
+                            </DataGridComboBoxColumn>
+                            <DataGridTextColumn Header="Amount" Binding="{Binding Amount, UpdateSourceTrigger=PropertyChanged}" Width="100">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Foreground" Value="Green"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Type}" Value="Debit">
+                                                <Setter Property="Foreground" Value="Red"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Header="Description" Binding="{Binding Description, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
                             <DataGridTemplateColumn Header="Actions" Width="200" IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                            <Button Content="Edit" Margin="0,0,5,0" Click="EditTransaction_Click"/>
-                                            <Button Content="Update" Margin="0,0,5,0" Tag="{Binding Id}" Click="UpdateTransaction_Click"/>
-                                            <Button Content="Delete" Tag="{Binding Id}" Click="DeleteTransaction_Click"/>
+                                            <Button Content="Edit" Margin="0,0,5,0" Click="EditTransaction_Click" Style="{StaticResource ActionButtonStyle}"/>
+                                            <Button Content="Update" Margin="0,0,5,0" Tag="{Binding Id}" Click="UpdateTransaction_Click" Style="{StaticResource ActionButtonStyle}"/>
+                                            <Button Content="Delete" Tag="{Binding Id}" Click="DeleteTransaction_Click" Style="{StaticResource DeleteButtonStyle}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
@@ -133,7 +170,7 @@
                                 <TextBlock Text="Description"/>
                                 <TextBox x:Name="AddTransactionDescriptionTextBox" Width="150" ToolTip="Optional description"/>
                             </StackPanel>
-                            <Button x:Name="AddTransactionButton" Content="Add Transaction" Margin="10,20,0,0" Click="AddTransaction_Click"/>
+                            <Button x:Name="AddTransactionButton" Content="Add Transaction" Margin="10,20,0,0" Click="AddTransaction_Click" Style="{StaticResource ActionButtonStyle}"/>
                         </StackPanel>
                         <TextBlock x:Name="AddTransactionErrorTextBlock" Foreground="Red" Margin="0,5,0,0"/>
                     </StackPanel>


### PR DESCRIPTION
## Summary
- Style transaction tab buttons for a more professional look
- Allow editing transaction type, amount and description with color-coded amounts
- Persist updates to server with rollback on failure

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*
- ⚠️ `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ce8ffc2288330b1e4694a4bbe28dd