### PR TITLE
Add admin-only data purge and shutdown controls

### DIFF
--- a/AccountingApp/DashboardWindow.xaml
+++ b/AccountingApp/DashboardWindow.xaml
@@ -334,7 +334,8 @@
                 <Grid Background="White">
                     <StackPanel Margin="20">
                         <TextBlock Text="Settings" FontSize="18"/>
-                        <Button x:Name="KillButton" Content="Kill Switch" Width="200" Height="35" Margin="0,20,0,0" Click="KillButton_Click"/>
+                        <Button x:Name="DeleteDataButton" Content="Delete All Data" Width="200" Height="35" Margin="0,20,0,0" Click="DeleteDataButton_Click"/>
+                        <Button x:Name="ShutdownButton" Content="Shutdown Server" Width="200" Height="35" Margin="0,10,0,0" Click="ShutdownButton_Click"/>
                     </StackPanel>
                 </Grid>
             </TabItem>

--- a/AccountingApp/DashboardWindow.xaml.cs
+++ b/AccountingApp/DashboardWindow.xaml.cs
@@ -48,7 +48,8 @@ namespace AccountingApp
             if (!_isAdmin)
             {
                 UsersTab.Visibility = Visibility.Collapsed;
-                KillButton.Visibility = Visibility.Collapsed;
+                DeleteDataButton.Visibility = Visibility.Collapsed;
+                ShutdownButton.Visibility = Visibility.Collapsed;
             }
 
             // Load data asynchronously after the window is loaded
@@ -412,17 +413,17 @@ namespace AccountingApp
             }
         }
 
-        // Kill switch to delete all server data
-        private async void KillButton_Click(object sender, RoutedEventArgs e)
+        // Delete all server data except vendor details
+        private async void DeleteDataButton_Click(object sender, RoutedEventArgs e)
         {
-            if (MessageBox.Show("This will delete all data. Are you sure?", "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+            if (MessageBox.Show("This will delete all data except vendor details. Are you sure?", "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
             {
                 try
                 {
-                    var response = await _httpClient.DeleteAsync("http://localhost:5000/api/admin/kill");
+                    var response = await _httpClient.DeleteAsync("http://localhost:5000/api/admin/purge");
                     if (response.IsSuccessStatusCode)
                     {
-                        MessageBox.Show("All data deleted.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                        MessageBox.Show("All non-vendor data deleted.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
                     }
                     else
                     {
@@ -432,7 +433,32 @@ namespace AccountingApp
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show($"Error invoking kill switch: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show($"Error deleting data: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        }
+
+        // Forcefully shutdown the server
+        private async void ShutdownButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MessageBox.Show("This will forcefully shut down the server. Are you sure?", "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+            {
+                try
+                {
+                    var response = await _httpClient.PostAsync("http://localhost:5000/api/admin/shutdown", null);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        MessageBox.Show("Server shutdown initiated.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                    }
+                    else
+                    {
+                        string error = await response.Content.ReadAsStringAsync();
+                        MessageBox.Show($"Failed to shut down server: {error}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Error shutting down server: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add "Delete All Data" and "Shutdown Server" buttons to Settings tab for administrators
- Hide new controls for non-admin users at runtime
- Wire up API calls to purge non-vendor data and initiate server shutdown

## Testing
- ⚠️ `dotnet build` *(missing `dotnet` CLI)*
- ⚠️ `apt-get update` *(repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cf847100c83308d6b722a645f4b0f