### PR TITLE
Fix clipped delete button and date picker in transaction grid

### DIFF
--- a/AccountingApp/DashboardWindow.xaml
+++ b/AccountingApp/DashboardWindow.xaml
@@ -153,14 +153,13 @@
                     </Style>
                     <Style x:Key="LargeCalendarStyle" TargetType="Calendar">
                         <Setter Property="Width" Value="250"/>
-                        <Setter Property="Height" Value="220"/>
                         <Setter Property="FontSize" Value="14"/>
                     </Style>
                 </TabItem.Resources>
                 <!-- Transaction management: view, add and delete transactions -->
                 <DockPanel>
                     <Button Content="Refresh" DockPanel.Dock="Top" Margin="10" Click="RefreshTransactions_Click" Style="{StaticResource AccentButtonStyle}"/>
-                    <DataGrid x:Name="TransactionsDataGrid" AutoGenerateColumns="False" Margin="10" DockPanel.Dock="Top" CanUserAddRows="False">
+                    <DataGrid x:Name="TransactionsDataGrid" AutoGenerateColumns="False" Margin="10" DockPanel.Dock="Top" CanUserAddRows="False" RowHeight="35">
                         <DataGrid.ColumnHeaderStyle>
                             <Style TargetType="DataGridColumnHeader">
                                 <Setter Property="HorizontalContentAlignment" Value="Center"/>


### PR DESCRIPTION
## Summary
- prevent calendar popup from clipping by removing fixed height
- ensure delete button fully visible by increasing transaction row height

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689d06501d088330afe47383ee82a24b