### PR TITLE
Center DataGrid headers and rows

### DIFF
--- a/AccountingApp/App.xaml
+++ b/AccountingApp/App.xaml
@@ -44,11 +44,16 @@
             <Setter Property="HeadersVisibility" Value="Column"/>
             <Setter Property="RowHeight" Value="30"/>
         </Style>
+        <Style TargetType="DataGridCell">
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="TextBlock.TextAlignment" Value="Center"/>
+        </Style>
         <Style TargetType="DataGridColumnHeader">
             <Setter Property="Background" Value="{StaticResource PrimaryBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
         </Style>
         <Style TargetType="TabControl">
             <Setter Property="BorderThickness" Value="0"/>

--- a/AccountingApp/DashboardWindow.xaml
+++ b/AccountingApp/DashboardWindow.xaml
@@ -187,6 +187,8 @@
                         </DataGrid.RowStyle>
                         <DataGrid.CellStyle>
                             <Style TargetType="DataGridCell">
+                                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                <Setter Property="TextBlock.TextAlignment" Value="Center"/>
                                 <Style.Triggers>
                                     <Trigger Property="IsSelected" Value="True">
                                         <Setter Property="Background" Value="#FFD0E7FF"/>
@@ -210,6 +212,7 @@
                             <DataGridTextColumn Header="Amount" Binding="{Binding Amount, UpdateSourceTrigger=PropertyChanged}" Width="100">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style TargetType="TextBlock">
+                                        <Setter Property="TextAlignment" Value="Center"/>
                                         <Setter Property="Foreground" Value="Green"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Type}" Value="Debit">


### PR DESCRIPTION
## Summary
- Center align DataGrid headers and cells across the application
- Ensure transaction grid cells and amount column text are centered

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d07119a0483309f05db68f8f39290